### PR TITLE
Preserve database data on server startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,15 +16,11 @@ app.use(express.static('public'));
 // 初始化数据库
 const db = new sqlite3.Database('dictation.db');
 
-// 创建表
+// 创建表（如不存在）
 db.serialize(() => {
-    // 删除旧表（如果存在）
-    db.run('DROP TABLE IF EXISTS word_attempts');
-    db.run('DROP TABLE IF EXISTS user_sessions');
-    db.run('DROP TABLE IF EXISTS word_stats');
     
     // 用户练习记录表
-    db.run(`CREATE TABLE user_sessions (
+    db.run(`CREATE TABLE IF NOT EXISTS user_sessions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         session_id TEXT UNIQUE,
         unit_name TEXT,
@@ -36,7 +32,7 @@ db.serialize(() => {
     )`);
 
     // 单词练习详情表
-    db.run(`CREATE TABLE word_attempts (
+    db.run(`CREATE TABLE IF NOT EXISTS word_attempts (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         session_id TEXT,
         word TEXT,
@@ -49,7 +45,7 @@ db.serialize(() => {
     )`);
 
     // 单词统计表
-    db.run(`CREATE TABLE word_stats (
+    db.run(`CREATE TABLE IF NOT EXISTS word_stats (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         word TEXT,
         unit_name TEXT,


### PR DESCRIPTION
## Summary
- avoid dropping existing tables in `server.js`
- create tables only if they don't exist

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fd54ae3a4832eb0f458926b6235d1