### PR TITLE
Add Google OAuth login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dictation.db

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 💾 **数据持久化**: 使用SQLite数据库保存学习记录和统计数据
 - 📚 **历史记录查看**: 查看过往练习记录和趋势
 - 📱 **响应式设计**: 支持手机、平板、电脑等设备
+- 🔐 **Google 登录**: 支持第三方登录，用户数据相互隔离
 
 ## 快速开始
 
@@ -19,6 +20,11 @@
    ```bash
    npm start
    ```
+
+   启动前请设置以下环境变量用于 Google 登录：
+   - `GOOGLE_CLIENT_ID`：Google OAuth 客户端 ID
+   - `GOOGLE_CLIENT_SECRET`：Google OAuth 客户端密钥
+   - `SESSION_SECRET`：用于会话加密的随机字符串
 
 3. 打开浏览器访问: http://localhost:3000
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "multer": "^2.0.1",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "express-session": "^1.17.3",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,11 @@
     <div class="container">
         <header class="header">
             <h1>🎧 雅思单词听写练习</h1>
+            <div class="auth-controls">
+                <span id="userInfo"></span>
+                <button class="btn" id="loginBtn">使用 Google 登录</button>
+                <button class="btn" id="logoutBtn" style="display:none;">退出</button>
+            </div>
         </header>
 
         <!-- 主菜单 -->

--- a/public/script.js
+++ b/public/script.js
@@ -18,7 +18,7 @@ class WordDictationApp {
         this.initializeElements();
         this.bindEvents();
         this.initializeVoices();
-        this.showMainMenu();
+        this.checkAuth();
     }
 
     initMobileOptimizations() {
@@ -73,6 +73,11 @@ class WordDictationApp {
         this.dictationSection = document.getElementById('dictationSection');
         this.resultSection = document.getElementById('resultSection');
         this.loading = document.getElementById('loading');
+
+        // Auth elements
+        this.loginBtn = document.getElementById('loginBtn');
+        this.logoutBtn = document.getElementById('logoutBtn');
+        this.userInfo = document.getElementById('userInfo');
 
         // Main menu buttons
         this.startPracticeBtn = document.getElementById('startPracticeBtn');
@@ -138,6 +143,14 @@ class WordDictationApp {
     }
 
     bindEvents() {
+        this.loginBtn.addEventListener('click', () => {
+            window.location.href = '/auth/google';
+        });
+        this.logoutBtn.addEventListener('click', async () => {
+            await fetch('/auth/logout', { method: 'POST' });
+            this.checkAuth();
+        });
+
         // Main menu
         this.startPracticeBtn.addEventListener('click', () => this.startPractice());
         this.viewStatsBtn.addEventListener('click', () => this.showStats());
@@ -197,8 +210,38 @@ class WordDictationApp {
         this.showSection(this.mainMenu);
     }
 
+    enableMainMenu(enabled) {
+        const buttons = [
+            this.startPracticeBtn,
+            this.viewStatsBtn,
+            this.viewHistoryBtn,
+            this.selectUnitBtn,
+            this.wordStatsBtn
+        ];
+        buttons.forEach(btn => btn.disabled = !enabled);
+    }
+
     showLoading(show) {
         this.loading.style.display = show ? 'flex' : 'none';
+    }
+
+    async checkAuth() {
+        try {
+            const res = await fetch('/api/user');
+            if (!res.ok) throw new Error('unauth');
+            const data = await res.json();
+            this.userInfo.textContent = data.displayName;
+            this.loginBtn.style.display = 'none';
+            this.logoutBtn.style.display = 'inline-block';
+            this.enableMainMenu(true);
+            this.showMainMenu();
+        } catch (e) {
+            this.userInfo.textContent = '';
+            this.loginBtn.style.display = 'inline-block';
+            this.logoutBtn.style.display = 'none';
+            this.enableMainMenu(false);
+            this.showMainMenu();
+        }
     }
 
     async startPractice(unitName) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -40,6 +40,14 @@ body {
     opacity: 0.9;
 }
 
+.auth-controls {
+    margin-top: 10px;
+}
+
+.auth-controls button {
+    margin-left: 5px;
+}
+
 /* Cards */
 .menu-card, .stats-card, .history-card, .word-card, .result-card {
     background: white;

--- a/server.js
+++ b/server.js
@@ -4,6 +4,9 @@ const bodyParser = require('body-parser');
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
 const path = require('path');
+const session = require('express-session');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
 
 const app = express();
 const PORT = 3000;
@@ -12,52 +15,117 @@ const PORT = 3000;
 app.use(cors());
 app.use(bodyParser.json());
 app.use(express.static('public'));
+app.use(
+    session({
+        secret: process.env.SESSION_SECRET || 'secret',
+        resave: false,
+        saveUninitialized: false
+    })
+);
+app.use(passport.initialize());
+app.use(passport.session());
 
 // 初始化数据库
 const db = new sqlite3.Database('dictation.db');
 
 // 创建表（如不存在）
 db.serialize(() => {
-    
-    // 用户练习记录表
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        google_id TEXT UNIQUE,
+        display_name TEXT,
+        email TEXT
+    )`);
+
     db.run(`CREATE TABLE IF NOT EXISTS user_sessions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         session_id TEXT UNIQUE,
+        user_id INTEGER,
         unit_name TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         total_words INTEGER,
         correct_words INTEGER,
         accuracy_rate REAL,
-        completed_at DATETIME
+        completed_at DATETIME,
+        FOREIGN KEY (user_id) REFERENCES users(id)
     )`);
 
-    // 单词练习详情表
     db.run(`CREATE TABLE IF NOT EXISTS word_attempts (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         session_id TEXT,
+        user_id INTEGER,
         word TEXT,
         unit_name TEXT,
         user_input TEXT,
         is_correct BOOLEAN,
         attempts INTEGER DEFAULT 1,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (session_id) REFERENCES user_sessions (session_id)
+        FOREIGN KEY (session_id) REFERENCES user_sessions (session_id),
+        FOREIGN KEY (user_id) REFERENCES users(id)
     )`);
 
-    // 单词统计表
     db.run(`CREATE TABLE IF NOT EXISTS word_stats (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
         word TEXT,
         unit_name TEXT,
         total_attempts INTEGER DEFAULT 0,
         correct_attempts INTEGER DEFAULT 0,
         accuracy_rate REAL DEFAULT 0,
         last_practiced DATETIME DEFAULT CURRENT_TIMESTAMP,
-        UNIQUE(word, unit_name)
+        UNIQUE(word, unit_name, user_id),
+        FOREIGN KEY (user_id) REFERENCES users(id)
     )`);
-    
+
+    // 旧表兼容：尝试添加缺失列
+    db.run('ALTER TABLE user_sessions ADD COLUMN user_id INTEGER', () => {});
+    db.run('ALTER TABLE word_attempts ADD COLUMN user_id INTEGER', () => {});
+    db.run('ALTER TABLE word_stats ADD COLUMN user_id INTEGER', () => {});
+
     console.log('Database tables created successfully');
 });
+
+// Passport配置
+passport.serializeUser((user, done) => {
+    done(null, user.id);
+});
+
+passport.deserializeUser((id, done) => {
+    db.get('SELECT * FROM users WHERE id = ?', [id], (err, row) => {
+        if (err) return done(err);
+        done(null, row);
+    });
+});
+
+passport.use(
+    new GoogleStrategy(
+        {
+            clientID: process.env.GOOGLE_CLIENT_ID || '',
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+            callbackURL: '/auth/google/callback'
+        },
+        (accessToken, refreshToken, profile, done) => {
+            const { id, displayName, emails } = profile;
+            db.get('SELECT * FROM users WHERE google_id = ?', [id], (err, row) => {
+                if (err) return done(err);
+                if (row) {
+                    return done(null, row);
+                }
+                db.run(
+                    'INSERT INTO users (google_id, display_name, email) VALUES (?, ?, ?)',
+                    [id, displayName, emails && emails[0] ? emails[0].value : null],
+                    function (err) {
+                        if (err) return done(err);
+                        db.get('SELECT * FROM users WHERE id = ?', [this.lastID], (err2, newRow) => {
+                            if (err2) return done(err2);
+                            done(null, newRow);
+                        });
+                    }
+                );
+            });
+        }
+    )
+);
 
 // 读取单词本并按单元分组
 function loadWordsByUnits() {
@@ -108,6 +176,36 @@ function generateSessionId() {
     return 'session_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
 }
 
+function ensureAuthenticated(req, res, next) {
+    if (req.isAuthenticated()) {
+        return next();
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+}
+
+// 登录相关路由
+app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+app.get('/auth/google/callback',
+    passport.authenticate('google', { failureRedirect: '/' }),
+    (req, res) => {
+        res.redirect('/');
+    }
+);
+
+app.post('/auth/logout', (req, res) => {
+    req.logout(() => {
+        res.json({ success: true });
+    });
+});
+
+app.get('/api/user', (req, res) => {
+    if (!req.isAuthenticated()) {
+        return res.status(401).json({ user: null });
+    }
+    res.json({ id: req.user.id, displayName: req.user.display_name });
+});
+
 // 获取单词列表
 app.get('/api/words', (req, res) => {
     const words = loadWords();
@@ -115,7 +213,7 @@ app.get('/api/words', (req, res) => {
 });
 
 // 开始新的练习会话
-app.post('/api/start-session', (req, res) => {
+app.post('/api/start-session', ensureAuthenticated, (req, res) => {
     const { unitName } = req.body;
     const sessionId = generateSessionId();
     
@@ -142,8 +240,8 @@ app.post('/api/start-session', (req, res) => {
     }
     
     db.run(
-        'INSERT INTO user_sessions (session_id, unit_name, total_words) VALUES (?, ?, ?)',
-        [sessionId, selectedUnitName, totalWords],
+        'INSERT INTO user_sessions (session_id, user_id, unit_name, total_words) VALUES (?, ?, ?, ?)',
+        [sessionId, req.user.id, selectedUnitName, totalWords],
         function(err) {
             if (err) {
                 console.error('Database error:', err);
@@ -160,7 +258,7 @@ app.post('/api/start-session', (req, res) => {
 });
 
 // 提交单词答案
-app.post('/api/submit-word', (req, res) => {
+app.post('/api/submit-word', ensureAuthenticated, (req, res) => {
     const { sessionId, word, userInput, isCorrect, unitName } = req.body;
     
     if (!sessionId || !word || userInput === undefined) {
@@ -169,8 +267,8 @@ app.post('/api/submit-word', (req, res) => {
 
     // 保存练习记录
     db.run(
-        'INSERT INTO word_attempts (session_id, word, unit_name, user_input, is_correct) VALUES (?, ?, ?, ?, ?)',
-        [sessionId, word, unitName, userInput, isCorrect],
+        'INSERT INTO word_attempts (session_id, user_id, word, unit_name, user_input, is_correct) VALUES (?, ?, ?, ?, ?, ?)',
+        [sessionId, req.user.id, word, unitName, userInput, isCorrect],
         function(err) {
             if (err) {
                 console.error('Database error:', err);
@@ -178,18 +276,18 @@ app.post('/api/submit-word', (req, res) => {
             }
             
             // 更新单词统计
-            updateWordStats(word, unitName, isCorrect);
+            updateWordStats(req.user.id, word, unitName, isCorrect);
             res.json({ success: true });
         }
     );
 });
 
 // 更新单词统计
-function updateWordStats(word, unitName, isCorrect) {
+function updateWordStats(userId, word, unitName, isCorrect) {
     const query = `
-        INSERT INTO word_stats (word, unit_name, total_attempts, correct_attempts, accuracy_rate, last_practiced)
-        VALUES (?, ?, 1, ?, ?, CURRENT_TIMESTAMP)
-        ON CONFLICT(word, unit_name) DO UPDATE SET
+        INSERT INTO word_stats (user_id, word, unit_name, total_attempts, correct_attempts, accuracy_rate, last_practiced)
+        VALUES (?, ?, ?, 1, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(word, unit_name, user_id) DO UPDATE SET
             total_attempts = total_attempts + 1,
             correct_attempts = correct_attempts + ?,
             accuracy_rate = CAST(correct_attempts AS REAL) / total_attempts * 100,
@@ -198,7 +296,7 @@ function updateWordStats(word, unitName, isCorrect) {
     
     const correctIncrement = isCorrect ? 1 : 0;
     
-    db.run(query, [word, unitName, correctIncrement, correctIncrement], (err) => {
+    db.run(query, [userId, word, unitName, correctIncrement, correctIncrement], (err) => {
         if (err) {
             console.error('Error updating word stats:', err);
         }
@@ -206,7 +304,7 @@ function updateWordStats(word, unitName, isCorrect) {
 }
 
 // 完成练习会话
-app.post('/api/complete-session', (req, res) => {
+app.post('/api/complete-session', ensureAuthenticated, (req, res) => {
     const { sessionId } = req.body;
     
     if (!sessionId) {
@@ -215,8 +313,8 @@ app.post('/api/complete-session', (req, res) => {
 
     // 计算统计数据
     db.all(
-        'SELECT COUNT(*) as total, SUM(CASE WHEN is_correct = 1 THEN 1 ELSE 0 END) as correct FROM word_attempts WHERE session_id = ?',
-        [sessionId],
+        'SELECT COUNT(*) as total, SUM(CASE WHEN is_correct = 1 THEN 1 ELSE 0 END) as correct FROM word_attempts WHERE session_id = ? AND user_id = ?',
+        [sessionId, req.user.id],
         (err, rows) => {
             if (err) {
                 console.error('Database error:', err);
@@ -229,8 +327,8 @@ app.post('/api/complete-session', (req, res) => {
 
             // 更新会话记录
             db.run(
-                'UPDATE user_sessions SET correct_words = ?, accuracy_rate = ?, completed_at = CURRENT_TIMESTAMP WHERE session_id = ?',
-                [correct, accuracyRate, sessionId],
+                'UPDATE user_sessions SET correct_words = ?, accuracy_rate = ?, completed_at = CURRENT_TIMESTAMP WHERE session_id = ? AND user_id = ?',
+                [correct, accuracyRate, sessionId, req.user.id],
                 function(err) {
                     if (err) {
                         console.error('Database error:', err);
@@ -249,16 +347,16 @@ app.post('/api/complete-session', (req, res) => {
 });
 
 // 获取历史统计
-app.get('/api/stats', (req, res) => {
+app.get('/api/stats', ensureAuthenticated, (req, res) => {
     db.all(
         `SELECT 
             COUNT(*) as total_sessions,
             AVG(accuracy_rate) as avg_accuracy,
             SUM(total_words) as total_words_practiced,
             SUM(correct_words) as total_correct_words
-        FROM user_sessions 
-        WHERE completed_at IS NOT NULL`,
-        (err, rows) => {
+        FROM user_sessions
+        WHERE completed_at IS NOT NULL AND user_id = ?`,
+        [req.user.id], (err, rows) => {
             if (err) {
                 console.error('Database error:', err);
                 return res.status(500).json({ error: 'Failed to get stats' });
@@ -276,7 +374,7 @@ app.get('/api/stats', (req, res) => {
 });
 
 // 获取最近的练习记录
-app.get('/api/recent-sessions', (req, res) => {
+app.get('/api/recent-sessions', ensureAuthenticated, (req, res) => {
     db.all(
         `SELECT 
             session_id,
@@ -286,11 +384,11 @@ app.get('/api/recent-sessions', (req, res) => {
             accuracy_rate,
             created_at,
             completed_at
-        FROM user_sessions 
-        WHERE completed_at IS NOT NULL
-        ORDER BY completed_at DESC 
+        FROM user_sessions
+        WHERE completed_at IS NOT NULL AND user_id = ?
+        ORDER BY completed_at DESC
         LIMIT 10`,
-        (err, rows) => {
+        [req.user.id], (err, rows) => {
             if (err) {
                 console.error('Database error:', err);
                 return res.status(500).json({ error: 'Failed to get recent sessions' });
@@ -328,11 +426,11 @@ app.get('/api/units/:unitName/words', (req, res) => {
 });
 
 // 获取单词统计
-app.get('/api/word-stats', (req, res) => {
+app.get('/api/word-stats', ensureAuthenticated, (req, res) => {
     const { unit, sortBy = 'accuracy', order = 'asc' } = req.query;
-    
+
     let query = `
-        SELECT 
+        SELECT
             word,
             unit_name,
             total_attempts,
@@ -340,12 +438,13 @@ app.get('/api/word-stats', (req, res) => {
             accuracy_rate,
             last_practiced
         FROM word_stats
+        WHERE user_id = ?
     `;
-    
-    const params = [];
-    
+
+    const params = [req.user.id];
+
     if (unit) {
-        query += ' WHERE unit_name = ?';
+        query += ' AND unit_name = ?';
         params.push(unit);
     }
     
@@ -366,7 +465,7 @@ app.get('/api/word-stats', (req, res) => {
 });
 
 // 获取单元统计
-app.get('/api/unit-stats', (req, res) => {
+app.get('/api/unit-stats', ensureAuthenticated, (req, res) => {
     const query = `
         SELECT 
             unit_name,
@@ -375,11 +474,12 @@ app.get('/api/unit-stats', (req, res) => {
             SUM(total_attempts) as total_attempts,
             MAX(last_practiced) as last_practiced
         FROM word_stats
+        WHERE user_id = ?
         GROUP BY unit_name
         ORDER BY unit_name
     `;
-    
-    db.all(query, (err, rows) => {
+
+    db.all(query, [req.user.id], (err, rows) => {
         if (err) {
             console.error('Database error:', err);
             return res.status(500).json({ error: 'Failed to get unit stats' });


### PR DESCRIPTION
## Summary
- integrate passport-google-oauth20 with express-session
- create users table and add user_id to stats tables
- secure API routes with authentication
- expose login/logout endpoints and user info API
- add login controls on the front-end
- document Google login setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2f1f264832ebac0fe78be8ed3f9